### PR TITLE
Update go dep to 1.22

### DIFF
--- a/Abstract/abstract-nexodus.rb
+++ b/Abstract/abstract-nexodus.rb
@@ -13,7 +13,7 @@ class AbstractNexodus < Formula
     version "#{ver}.#{tag}-#{date}-#{sha}"
     url "https://github.com/nexodus-io/nexodus/archive/#{sha}.tar.gz"   
 
-    depends_on "go@1.21" => :build
+    depends_on "go@1.22" => :build
     if OS.mac?
       depends_on "nexd-wireguard-go" => :recommended
     end

--- a/Formula/nexd-wireguard-go.rb
+++ b/Formula/nexd-wireguard-go.rb
@@ -11,7 +11,7 @@ class NexdWireguardGo < Formula
   url "https://github.com/nexodus-io/wireguard-go/archive/refs/tags/#{version}.tar.gz"
   sha256 "2f8e546f92f85917c275bf04e01ad7f2db19e14cfe7c156c5861540570ac797d"
 
-  depends_on "go@1.20" => :build
+  depends_on "go@1.22" => :build
 
   def install
     ENV["CGO_ENABLED"] = "0"


### PR DESCRIPTION
Nexodus now depends on 1.22, so update our go dependency to reflect that.